### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v8
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/grzegorz914/homebridge-meraki-control/security/code-scanning/1](https://github.com/grzegorz914/homebridge-meraki-control/security/code-scanning/1)

To fix this, add an explicit `permissions` block that grants only the scopes required by `actions/stale` to operate: it needs to read repo contents and read/write issues and pull requests. The safest, least-privilege configuration aligned with the CodeQL recommendation is to set `contents: write`, `issues: write`, and `pull-requests: write`. These can be set either at the workflow level (applies to all jobs) or at the job level (just for `stale`). Since the warning is on the job and this workflow has a single job, defining `permissions` under that job is clean and minimally invasive.

Concretely, in `.github/workflows/stale.yml`, under `jobs: stale:`, add a `permissions:` section at the same indentation level as `runs-on:` and before the `steps:` block. No imports or additional methods are needed; this is purely a YAML configuration change. Functionality remains the same, but the effective permissions of `GITHUB_TOKEN` are now explicitly constrained.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
